### PR TITLE
Test & target .NET Core App 2.2 & 3.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,12 +19,11 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-- cmd: curl -O https://dot.net/v1/dotnet-install.ps1
+- cmd: curl -O https://download.visualstudio.microsoft.com/download/pr/53f250a1-318f-4350-8bda-3c6e49f40e76/e8cbbd98b08edd6222125268166cfc43/dotnet-sdk-3.0.100-win-x64.exe
 - sh: curl -O https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
 - ps: |
-    $sdkVersion = (type .\global.json | ConvertFrom-Json).sdk.version
-    if ($isWindows) { ./dotnet-install.ps1 -Version $sdkVersion }
+    if ($isWindows) { dotnet-sdk-3.0.100-win-x64.exe -q }
     if ($isLinux)   { ./dotnet-install.sh --version $sdkVersion }
 - sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet
 - sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,9 @@ install:
 - ps: |
     $sdkVersion = (type .\global.json | ConvertFrom-Json).sdk.version
     if ($isWindows) { ./dotnet-install.ps1 -Version $sdkVersion }
-    if ($isLinux) {
-      ./dotnet-install.sh --version $sdkVersion
-      ./dotnet-install.sh --version 2.1.13 --runtime dotnet
-    }
+    if ($isLinux)   { ./dotnet-install.sh --version $sdkVersion }
+- sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet
+- sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,9 @@ environment:
 install:
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
 - ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version $sdkVersion }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7       }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3       }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version $env:DOTNET_SDK_VERSION }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7 }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3 }
 - cmd: set PATH=%CD%\.dotnet;%PATH%
 - sh:  curl -O https://dot.net/v1/dotnet-install.sh
 - sh:  chmod +x dotnet-install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,16 +21,16 @@ environment:
 install:
 - ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -Version $sdkVersion -InstallDir .dotnet }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -Version 2.2.7 -InstallDir .dotnet }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -Version 2.1.3 -InstallDir .dotnet }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version $sdkVersion }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7       }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3       }
 - cmd: set PATH=%CD%\.dotnet;%PATH%
 - sh:  curl -O https://dot.net/v1/dotnet-install.sh
 - sh:  chmod +x dotnet-install.sh
-- sh: ./dotnet-install.sh --version $DOTNET_SDK_VERSION --install-dir .dotnet
-- sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet --install-dir .dotnet
-- sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet --install-dir .dotnet
-- sh: export PATH="$PWD/.dotnet:$PATH"
+- sh:  ./dotnet-install.sh --install-dir .dotnet --version $DOTNET_SDK_VERSION
+- sh:  ./dotnet-install.sh --install-dir .dotnet --version 2.2.7 --runtime dotnet
+- sh:  ./dotnet-install.sh --install-dir .dotnet --version 2.1.3 --runtime dotnet
+- sh:  export PATH="$PWD/.dotnet:$PATH"
 - ps: |
     if ($isWindows) { $env:PATH -split ';' | echo }
     if ($isLinux  ) { $env:PATH -split ':' | echo }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,16 +19,18 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
+- ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
-- sh: curl -O https://dot.net/v1/dotnet-install.sh
-- sh: chmod +x dotnet-install.sh
-- ps: |
-    $sdkVersion = (type .\global.json | ConvertFrom-Json).sdk.version
-    if ($isWindows) { ./dotnet-install.ps1 -Version $sdkVersion }
-    if ($isLinux)   { ./dotnet-install.sh --version $sdkVersion }
-- sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet
-- sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet
-- sh: export PATH="$HOME/.dotnet:$PATH"
+- cmd: ./dotnet-install.ps1 -Version $sdkVersion -InstallDir .dotnet
+- cmd: ./dotnet-install.ps1 -Version 2.2.7 -InstallDir .dotnet
+- cmd: ./dotnet-install.ps1 -Version 2.1.3 -InstallDir .dotnet
+- cmd: set PATH=%CD%\.dotnet;%PATH%
+- sh:  curl -O https://dot.net/v1/dotnet-install.sh
+- sh:  chmod +x dotnet-install.sh
+- sh: ./dotnet-install.sh --version $DOTNET_SDK_VERSION --install-dir .dotnet
+- sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet --install-dir .dotnet
+- sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet --install-dir .dotnet
+- sh: export PATH="$PWD/.dotnet:$PATH"
 before_build:
 - dotnet --info
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
 - cmd: curl -O https://download.visualstudio.microsoft.com/download/pr/53f250a1-318f-4350-8bda-3c6e49f40e76/e8cbbd98b08edd6222125268166cfc43/dotnet-sdk-3.0.100-win-x64.exe
-- cmd: dotnet-sdk-3.0.100-win-x64.exe -q
+- cmd: dotnet-sdk-3.0.100-win-x64.exe /quiet /norestart
 - sh: curl -O https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
 - sh: ./dotnet-install.sh --version 3.0.100

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,10 +27,9 @@ install:
 - cmd: set PATH=%CD%\.dotnet;%PATH%
 - sh:  curl -O https://dot.net/v1/dotnet-install.sh
 - sh:  chmod +x dotnet-install.sh
-- sh:  ./dotnet-install.sh --install-dir .dotnet --version $DOTNET_SDK_VERSION
-- sh:  ./dotnet-install.sh --install-dir .dotnet --version 2.2.7 --runtime dotnet
-- sh:  ./dotnet-install.sh --install-dir .dotnet --version 2.1.3 --runtime dotnet
-- sh:  export PATH="$PWD/.dotnet:$PATH"
+- sh:  . dotnet-install.sh --install-dir .dotnet --version $DOTNET_SDK_VERSION
+- sh:  . dotnet-install.sh --install-dir .dotnet --version 2.2.7 --runtime dotnet
+- sh:  . dotnet-install.sh --install-dir .dotnet --version 2.1.3 --runtime dotnet
 - ps: |
     if ($isWindows) { $env:PATH -split ';' | echo }
     if ($isLinux  ) { $env:PATH -split ':' | echo }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-- ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
+- ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
 - ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version $sdkVersion }
 - ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7       }
 - ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,9 +21,9 @@ environment:
 install:
 - ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
-- cmd: ./dotnet-install.ps1 -Version $sdkVersion -InstallDir .dotnet
-- cmd: ./dotnet-install.ps1 -Version 2.2.7 -InstallDir .dotnet
-- cmd: ./dotnet-install.ps1 -Version 2.1.3 -InstallDir .dotnet
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -Version $sdkVersion -InstallDir .dotnet }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -Version 2.2.7 -InstallDir .dotnet }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -Version 2.1.3 -InstallDir .dotnet }
 - cmd: set PATH=%CD%\.dotnet;%PATH%
 - sh:  curl -O https://dot.net/v1/dotnet-install.sh
 - sh:  chmod +x dotnet-install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,11 +20,10 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
 - cmd: curl -O https://download.visualstudio.microsoft.com/download/pr/53f250a1-318f-4350-8bda-3c6e49f40e76/e8cbbd98b08edd6222125268166cfc43/dotnet-sdk-3.0.100-win-x64.exe
+- cmd: dotnet-sdk-3.0.100-win-x64.exe -q
 - sh: curl -O https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
-- ps: |
-    if ($isWindows) { dotnet-sdk-3.0.100-win-x64.exe -q }
-    if ($isLinux)   { ./dotnet-install.sh --version $sdkVersion }
+- sh: ./dotnet-install.sh --version 3.0.100
 - sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet
 - sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet
 - sh: export PATH="$HOME/.dotnet:$PATH"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,21 +20,16 @@ environment:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
-- ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version $env:DOTNET_SDK_VERSION }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7 -Runtime dotnet }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3 -Runtime dotnet }
-- cmd: set PATH=%CD%\.dotnet;%PATH%
-- sh:  curl -O https://dot.net/v1/dotnet-install.sh
-- sh:  chmod +x dotnet-install.sh
-- sh:  . dotnet-install.sh --install-dir .dotnet --version $DOTNET_SDK_VERSION
-- sh:  . dotnet-install.sh --install-dir .dotnet --version 2.2.7 --runtime dotnet
-- sh:  . dotnet-install.sh --install-dir .dotnet --version 2.1.3 --runtime dotnet
+- sh: curl -O https://dot.net/v1/dotnet-install.sh
+- sh: chmod +x dotnet-install.sh
 - ps: |
-    if ($isWindows) { $env:PATH -split ';' | echo }
-    if ($isLinux  ) { $env:PATH -split ':' | echo }
+    $sdkVersion = (type .\global.json | ConvertFrom-Json).sdk.version
+    if ($isWindows) { ./dotnet-install.ps1 -Version $sdkVersion }
+    if ($isLinux)   { ./dotnet-install.sh --version $sdkVersion }
+- sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet
+- sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet
+- sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
-- which dotnet
 - dotnet --info
 build_script:
 - ps: >-
@@ -43,6 +38,7 @@ build_script:
     $id = $id.Substring(0, 13)
 
     if ($isWindows) { .\pack.cmd ci-$id } else { ./pack.sh ci-$id }
+- sh: export PATH="$HOME/.dotnet:$PATH"
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,9 @@ install:
 - sh: ./dotnet-install.sh --version 2.2.7 --runtime dotnet --install-dir .dotnet
 - sh: ./dotnet-install.sh --version 2.1.3 --runtime dotnet --install-dir .dotnet
 - sh: export PATH="$PWD/.dotnet:$PATH"
+- ps: |
+    if ($isWindows) { $env:PATH -split ';' | echo }
+    if ($isLinux  ) { $env:PATH -split ':' | echo }
 before_build:
 - dotnet --info
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,6 @@ build_script:
     $id = $id.Substring(0, 13)
 
     if ($isWindows) { .\pack.cmd ci-$id } else { ./pack.sh ci-$id }
-- sh: export PATH="$HOME/.dotnet:$PATH"
 test_script:
 - cmd: test.cmd
 - sh: ./test.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,8 @@ install:
 - cmd: curl -O https://dot.net/v1/dotnet-install.ps1
 - ps:  $env:DOTNET_SDK_VERSION = (type .\global.json | ConvertFrom-Json).sdk.version
 - ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version $env:DOTNET_SDK_VERSION }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7 }
-- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3 }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.2.7 -Runtime dotnet }
+- ps:  if ($isWindows) { ./dotnet-install.ps1 -InstallDir .dotnet -Version 2.1.3 -Runtime dotnet }
 - cmd: set PATH=%CD%\.dotnet;%PATH%
 - sh:  curl -O https://dot.net/v1/dotnet-install.sh
 - sh:  chmod +x dotnet-install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@ install:
     if ($isWindows) { $env:PATH -split ';' | echo }
     if ($isLinux  ) { $env:PATH -split ':' | echo }
 before_build:
+- which dotnet
 - dotnet --info
 build_script:
 - ps: >-

--- a/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
+++ b/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <VersionPrefix>1.2.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csmin</ToolCommandName>

--- a/tests/CSharpMinifier.Tests.csproj
+++ b/tests/CSharpMinifier.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.0;netcoreapp2.2;netcoreapp2.1</TargetFrameworks>
     <LangVersion>7.1</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR adds .NET Core App 2.2 & 3.0 as targets. Since the global tool install is an [FDD (framework-dependent deployment)](https://docs.microsoft.com/en-us/dotnet/core/deploying/#framework-dependent-deployments-fdd), this avoids forcing user to install older runtimes if a later compatible version is available.