### PR TITLE
Update to .NET 5 SDK

### DIFF
--- a/CSharpMinifier.sln
+++ b/CSharpMinifier.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpMinifier", "src\CSharpMinifier\CSharpMinifier.csproj", "{2143359D-1770-4173-8C87-9024627A1179}"
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ install:
 - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
 - sh: ./dotnet-install.sh --jsonfile global.json
+- sh: ./dotnet-install.sh --version 3.1.10 --runtime dotnet
 - sh: ./dotnet-install.sh --version 2.1.23 --runtime dotnet
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:

--- a/csmin.cmd
+++ b/csmin.cmd
@@ -1,1 +1,1 @@
-@dotnet run --no-launch-profile -f netcoreapp3.1 -p "%~dp0src\CSharpMinifierConsole" -- %*
+@dotnet run --no-launch-profile -f net5.0 -p "%~dp0src\CSharpMinifierConsole" -- %*

--- a/csmin.sh
+++ b/csmin.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 set -e
-dotnet run --no-launch-profile -f netcoreapp3.1 -p "$(dirname "$0")/src/CSharpMinifierConsole" -- "$@"
+dotnet run --no-launch-profile -f net5.0 -p "$(dirname "$0")/src/CSharpMinifierConsole" -- "$@"

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.300"
+    "version": "5.0.100",
+    "rollForward": "latestFeature"
   }
 }

--- a/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
+++ b/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <VersionPrefix>1.3.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csmin</ToolCommandName>

--- a/src/CSharpMinifierConsole/Help.cs
+++ b/src/CSharpMinifierConsole/Help.cs
@@ -10,7 +10,7 @@ namespace CSharpMinifierConsole
 
     partial class Program
     {
-        static readonly Lazy<FileVersionInfo> CachedVersionInfo = Lazy.Create(() => FileVersionInfo.GetVersionInfo(new Uri(typeof(Program).Assembly.CodeBase).LocalPath));
+        static readonly Lazy<FileVersionInfo> CachedVersionInfo = Lazy.Create(() => FileVersionInfo.GetVersionInfo(typeof(Program).Assembly.Location));
         static FileVersionInfo VersionInfo => CachedVersionInfo.Value;
 
         static void Help(string command, MonoOptionSet options) =>

--- a/src/CSharpMinifierConsole/NDesk.Options.cs
+++ b/src/CSharpMinifierConsole/NDesk.Options.cs
@@ -490,7 +490,6 @@ namespace Mono.Options
 			get {return this.option;}
 		}
 
-		[SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
 		public override void GetObjectData (SerializationInfo info, StreamingContext context)
 		{
 			base.GetObjectData (info, context);

--- a/tests/CSharpMinifier.Tests.csproj
+++ b/tests/CSharpMinifier.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
This PR updates to .NET 5 SDK and addresses the following warnings:

    src\CSharpMinifierConsole\NDesk.Options.cs(493,4,493,22): warning SYSLIB0003: 'SecurityPermissionAttribute' is obsolete: 'Code Access Security is not supported or honored by the runtime.'
    src\CSharpMinifierConsole\NDesk.Options.cs(493,24,493,38): warning SYSLIB0003: 'SecurityAction' is obsolete: 'Code Access Security is not supported or honored by the runtime.'
    src\CSharpMinifierConsole\Help.cs(13,124,13,157): warning SYSLIB0012: 'Assembly.CodeBase' is obsolete: 'Assembly.CodeBase and Assembly.EscapedCodeBase are only included for .NET Framework compatibility. Use Assembly.Location instead.'