### PR TITLE
Update ThisAssembly.AssemblyInfo to latest version

### DIFF
--- a/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
+++ b/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="5.0.0" />
-    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.0.3" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.0.9" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes false positive error that, "ThisAssembly requires MSBuild 16.8+ or .NET SDK 5.0+".