### PR TITLE
Drop .NET Core 2.1 runtime target that's no longer supported

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,6 @@ install:
 - sh: ./dotnet-install.sh --jsonfile global.json
 - sh: ./dotnet-install.sh --version 5.0.12 --runtime dotnet
 - sh: ./dotnet-install.sh --version 3.1.10 --runtime dotnet
-- sh: ./dotnet-install.sh --version 2.1.23 --runtime dotnet
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
+++ b/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <VersionPrefix>1.3.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csmin</ToolCommandName>

--- a/tests/CSharpMinifier.Tests.csproj
+++ b/tests/CSharpMinifier.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR removes targeting .NET Core 2.1 that's reached [end-of-life and therefore no longer supported](https://dotnet.microsoft.com/platform/support/policy/dotnet-core).