### PR TITLE
Update more structs to be of type record where applicable

### DIFF
--- a/src/CSharpMinifier/CSharpMinifier.csproj
+++ b/src/CSharpMinifier/CSharpMinifier.csproj
@@ -22,6 +22,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="..\..\COPYING.txt" Pack="true" PackagePath="$(PackageLicenseFile)" />
   </ItemGroup>
 

--- a/src/CSharpMinifier/CSharpString.cs
+++ b/src/CSharpMinifier/CSharpString.cs
@@ -30,7 +30,7 @@ namespace CSharpMinifier
         InvalidHexadecimalEscapeSequence,
     }
 
-    readonly struct StringValueParseResult : IEquatable<StringValueParseResult>
+    readonly record struct StringValueParseResult
     {
         public StringValueParseResultStatus Status { get; }
         public int ErrorOffset { get; }
@@ -48,23 +48,6 @@ namespace CSharpMinifier
             ErrorOffset = errorOffset;
             Value       = value;
         }
-
-        public bool Equals(StringValueParseResult other)
-            => Status == other.Status
-            && ErrorOffset == other.ErrorOffset
-            && string.Equals(Value, other.Value);
-
-        public override bool Equals(object obj) =>
-            obj is StringValueParseResult other && Equals(other);
-
-        public override int GetHashCode() =>
-            unchecked(((int) Status * 397) ^ ErrorOffset * 397 ^ (Value != null ? Value.GetHashCode() : 0));
-
-        public static bool operator ==(StringValueParseResult left, StringValueParseResult right) =>
-            left.Equals(right);
-
-        public static bool operator !=(StringValueParseResult left, StringValueParseResult right) =>
-            !left.Equals(right);
 
         public override string ToString()
             => Status == StringValueParseResultStatus.Success ? Value ?? string.Empty

--- a/src/CSharpMinifier/Position.cs
+++ b/src/CSharpMinifier/Position.cs
@@ -18,7 +18,7 @@ namespace CSharpMinifier
 {
     using System;
 
-    public readonly struct Position : IEquatable<Position>
+    public readonly record struct Position
     {
         readonly int _line;
         readonly int _column;
@@ -37,21 +37,6 @@ namespace CSharpMinifier
             _line   = line - 1;
             _column = column - 1;
         }
-
-        public bool Equals(Position other) =>
-            Offset == other.Offset && Line == other.Line && Column == other.Column;
-
-        public override bool Equals(object? obj) =>
-            obj is Position other && Equals(other);
-
-        public override int GetHashCode() =>
-            unchecked((((Offset * 397) ^ Line) * 397) ^ Column);
-
-        public static bool operator ==(Position left, Position right) =>
-            left.Equals(right);
-
-        public static bool operator !=(Position left, Position right) =>
-            !left.Equals(right);
 
         public override string ToString() => $"{Offset}/{Line}:{Column}";
     }

--- a/src/CSharpMinifier/Token.cs
+++ b/src/CSharpMinifier/Token.cs
@@ -57,31 +57,12 @@ namespace CSharpMinifier
             (kind.GetTraits() & traits) == traits;
     }
 
-    public readonly struct Token : IEquatable<Token>
+    public readonly record struct Token(TokenKind Kind, Position Start, Position End)
     {
-        public readonly TokenKind Kind;
-        public readonly Position Start;
-        public readonly Position End;
-
-        public Token(TokenKind kind, Position start, Position end) =>
-            (Kind, Start, End) = (kind, start, end);
-
         public int Length => End.Offset - Start.Offset;
 
         [Obsolete("Use " + nameof(TokenKindExtensions) + "." + nameof(TokenKindExtensions.GetTraits) + " instead.")]
         public TokenKindTraits Traits => Kind.GetTraits();
-
-        public bool Equals(Token other) =>
-            Kind == other.Kind && Start.Equals(other.Start) && End.Equals(other.End);
-
-        public override bool Equals(object obj) =>
-            obj is Token other && Equals(other);
-
-        public override int GetHashCode() =>
-            unchecked(((((int)Kind * 397) ^ Start.GetHashCode()) * 397) ^ End.GetHashCode());
-
-        public static bool operator ==(Token left, Token right) => left.Equals(right);
-        public static bool operator !=(Token left, Token right) => !left.Equals(right);
 
         public override string ToString() =>
             $"{Kind} [{Start}..{End})";


### PR DESCRIPTION
This PR converts the following `struct` types to be of type `record struct`.

Note that this introduces a breaking change for `Token`, where the fields are now properties.