### PR TITLE
Update .NET SDK (8), dependencies & runtime targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,11 +5,11 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
-    <AnalysisLevel>5.0</AnalysisLevel>
+    <AnalysisLevel>8.0</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nullable" Version="1.3.0">
+    <PackageReference Include="Nullable" Version="1.3.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,8 +25,7 @@ install:
 - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
 - sh: ./dotnet-install.sh --jsonfile global.json
-- sh: ./dotnet-install.sh --version 5.0.12 --runtime dotnet
-- sh: ./dotnet-install.sh --version 3.1.10 --runtime dotnet
+- sh: ./dotnet-install.sh --version 6.0.25 --runtime dotnet
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.100",
+    "version": "8.0.300",
     "rollForward": "latestPatch"
   }
 }

--- a/src/CSharpMinifier/CSharpMinifier.csproj
+++ b/src/CSharpMinifier/CSharpMinifier.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <Copyright>Copyright © 2019 Atif Aziz. All rights reserved.</Copyright>
     <Description>C# Minification Library</Description>
     <Authors>Atif Aziz</Authors>
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngryArrays" Version="1.1.0" />
-    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
+++ b/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <RootNamespace></RootNamespace>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <VersionPrefix>2.1.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csmin</ToolCommandName>
     <Copyright>Copyright © 2019 Atif Aziz. All rights reserved.</Copyright>
@@ -35,9 +35,9 @@
 
   <ItemGroup>
     <PackageReference Include="docopt.net" Version="0.8.1" />
-    <PackageReference Include="IsExternalInit" Version="1.0.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
-    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.0.9" />
+    <PackageReference Include="IsExternalInit" Version="1.0.3" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.4.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/CSharpMinifier.Tests.csproj
+++ b/tests/CSharpMinifier.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -12,15 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.1.0" />
-    <PackageReference Include="morelinq" Version="3.3.2" />
-    <PackageReference Include="nunit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="morelinq" Version="4.2.0" />
+    <PackageReference Include="nunit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.0.117" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The following unsupported run-time targets were removed:

- .NET 5
- .NET Core 3.1

The following run-time targets were added:

- .NET 8