### PR TITLE
Update .NET SDK (10), dependencies & runtime targets

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AnalysisLevel>8.0-all</AnalysisLevel>
+    <AnalysisLevel>10.0-all</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,15 @@ pull_requests:
 skip_tags: true
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  DOTNET_NOLOGO: true
 install:
 - cmd: curl -OsSL https://dot.net/v1/dotnet-install.ps1
 - ps: if ($isWindows) { ./dotnet-install.ps1 -JsonFile global.json }
+- ps: if ($isWindows) { ./dotnet-install.ps1 -Runtime dotnet -Version 8.0.22 -SkipNonVersionedFiles }
 - sh: curl -OsSL https://dot.net/v1/dotnet-install.sh
 - sh: chmod +x dotnet-install.sh
 - sh: ./dotnet-install.sh --jsonfile global.json
-- sh: ./dotnet-install.sh --version 6.0.25 --runtime dotnet
+- sh: ./dotnet-install.sh --version 8.0.22 --runtime dotnet --skip-non-versioned-files
 - sh: export PATH="$HOME/.dotnet:$PATH"
 before_build:
 - dotnet --info

--- a/csmin.cmd
+++ b/csmin.cmd
@@ -1,1 +1,1 @@
-@dotnet run --no-launch-profile -f net6.0 --project "%~dp0src\CSharpMinifierConsole" -- %*
+@dotnet run --no-launch-profile -f net10.0 --project "%~dp0src\CSharpMinifierConsole" -- %*

--- a/csmin.sh
+++ b/csmin.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 set -e
-dotnet run --no-launch-profile -f net6.0 --project "$(dirname "$0")/src/CSharpMinifierConsole" -- "$@"
+dotnet run --no-launch-profile -f net10.0 --project "$(dirname "$0")/src/CSharpMinifierConsole" -- "$@"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "10.0.100",
     "rollForward": "latestPatch"
   }
 }

--- a/src/CSharpMinifier/CSharpMinifier.csproj
+++ b/src/CSharpMinifier/CSharpMinifier.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <Copyright>Copyright © 2019 Atif Aziz. All rights reserved.</Copyright>
     <Description>C# Minification Library</Description>
     <Authors>Atif Aziz</Authors>
@@ -22,7 +22,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
+++ b/src/CSharpMinifierConsole/CSharpMinifierConsole.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <RootNamespace></RootNamespace>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
-    <VersionPrefix>2.1.0</VersionPrefix>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>csmin</ToolCommandName>
     <Copyright>Copyright © 2019 Atif Aziz. All rights reserved.</Copyright>
@@ -36,12 +36,12 @@
   <ItemGroup>
     <PackageReference Include="AngryArrays" Version="1.1.0" />
     <PackageReference Include="docopt.net" Version="0.8.1" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-    <PackageReference Include="PolySharp" Version="1.14.1">
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.1" />
+    <PackageReference Include="PolySharp" Version="1.15.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="1.4.3" />
+    <PackageReference Include="ThisAssembly.AssemblyInfo" Version="2.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/CSharpMinifierConsole/HashCommand.cs
+++ b/src/CSharpMinifierConsole/HashCommand.cs
@@ -45,7 +45,7 @@ partial class Program
         var format
             = args.OptFormat is { } fs
             ? Enum.TryParse<HashOutputFormat>(fs, true, out var fv)
-              && Enum.IsDefined(typeof(HashOutputFormat), fv) ? fv
+              && Enum.IsDefined(fv) ? fv
             : throw new Exception("Invalid hash format.")
             : HashOutputFormat.Hexadecimal;
 
@@ -79,9 +79,13 @@ partial class Program
         {
             case HashOutputFormat.Hexadecimal:
             {
-                Console.WriteLine(BitConverter.ToString(hash)
-                                              .Replace("-", string.Empty, StringComparison.Ordinal)
-                                              .ToLowerInvariant());
+                Console.WriteLine(
+#if NET8_0
+                    Convert.ToHexString(hash).ToLowerInvariant()
+#else
+                    Convert.ToHexStringLower(hash)
+#endif
+                );
                 break;
             }
             case HashOutputFormat.Base32:

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -7,3 +7,6 @@ dotnet_diagnostic.CA1062.severity = none
 
 # CA1034: Nested types should not be visible
 dotnet_diagnostic.CA1034.severity = none
+
+# CA1515: Consider making public types internal
+dotnet_diagnostic.CA1515.severity = none

--- a/tests/CSharpMinifier.Tests.csproj
+++ b/tests/CSharpMinifier.Tests.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -12,15 +12,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="morelinq" Version="4.2.0" />
-    <PackageReference Include="nunit" Version="4.1.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="NunitXml.TestLogger" Version="3.1.20" />
+    <PackageReference Include="morelinq" Version="4.4.0" />
+    <PackageReference Include="nunit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NunitXml.TestLogger" Version="7.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/TokenKindTests.cs
+++ b/tests/TokenKindTests.cs
@@ -52,7 +52,7 @@ namespace CSharpMinifier.Tests
         [Test]
         public void InvalidKind()
         {
-            var kinds = (TokenKind[])Enum.GetValues(typeof(TokenKind));
+            var kinds = Enum.GetValues<TokenKind>();
 
             var min = kinds.Min();
             Assert.Throws<ArgumentOutOfRangeException>(() =>


### PR DESCRIPTION
This PR upgrades the project to .NET 10, updates dependencies, and makes minor code changes to satisfy new analyzer warnings.

It replaces .NET 6 as a run-time targeted since it is no longer supported and instead adds .NET 10.